### PR TITLE
Use shared navigation partial and highlight active menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,5 @@ You can see the site here: https://samgamgy.github.io/PrivateSchool/
 Stock photos from Pexels
 
 
+
+Navigation is shared via nav.html partial loaded dynamically on each page.

--- a/contact.html
+++ b/contact.html
@@ -27,44 +27,7 @@
     gtag('config', 'G-GM7D4Q3929');
     </script>
     <body>
-        <header>
-            <nav>
-                <ul class="nav-bar" id="topNav">
-                    <img class='logo' src="./assets/fav-icon/apple-touch-icon.png" alt=""> 
-                    <li class="nav-logo ">
-                        <a class='hover-underline-animation' href="./index.html">
-                            <span class="long"> Montessori Lab School </span>
-                            <span class="short"> MLS </span>
-                        </a> 
-                        <span class="sub-text">since 1977</span>
-                    </li>
-                    <li class="phone-nav"><a href="tel:7575488762">(757) 548-8762</a> </li>
-                    <div class="menu">
-                        <li class="home-sub menu-items hover-underline-animation"><a href="./index.html">Home</a></li>
-                        <li class="menu-items hover-underline-animation"><a href="./programs.html">Curriculum</a>
-                            <ul class="sub-nav-items">
-                                <li><a href="./programs.html#pre-school">Pre-School Programs</a></li>
-                                <li><a href="./programs.html#elementary">Elementary Program</a></li>
-                                <li><a href="./programs.html#admission">Admissions Process</a></li>
-                            </ul>
-                        </li>
-                        <li class="menu-items hover-underline-animation"><a href="./parents.html">Parents</a>
-                            <ul class="sub-nav-items">
-                                <li><a href="./parents.html#what-is-montessori">What is Montessori?</a></li>
-                                <li><a href="./parents.html#calender">School Calendar</a></li>
-                                <li><a href="./parents.html#reading">Recommended Reading</a></li>
-                            </ul>
-                            </li>
-                        <li class="active menu-items hover-underline-animation"><a href="./contact.html">Contact</a></li>
-                    </div>
-                    <li class="icon"> 
-                        <a href="javascript:void(0);" class="icon" onclick="navBarMobile()">
-                            <i class="fa fa-bars"></i>
-                        </a>
-                    </li>
-                </ul>
-            </nav>
-        </header>    
+        <header id="nav"></header>
         
         
         <section class="contact-section">

--- a/index.html
+++ b/index.html
@@ -35,44 +35,8 @@
                 <a class='admin-icon' target="_blank" href="./contact.html"><i class="fa-solid fa-file-lines"></i></a>
             </div>
         </div>
-        <header>
-            <nav>
-                <ul class="nav-bar" id="topNav">
-                    <img class='logo' src="./assets/fav-icon/apple-touch-icon.png" alt=""> 
-                    <li class="nav-logo ">
-                        <a class='active hover-underline-animation' href="./index.html">
-                            <span class="long"> Montessori Lab School </span>
-                            <span class="short"> MLS </span>
-                        </a> 
-                    </li>
-                    <li class="phone-nav"><a href="tel:7575488762">(757) 548-8762</a> </li>
-                    <div class="menu">
-                        <li class="home-sub menu-items hover-underline-animation"><a href="./index.html">Home</a></li>
-                        <li class="menu-items hover-underline-animation"><a href="./programs.html">Curriculum</a>
-                            <ul class="sub-nav-items">
-                                <li><a href="./programs.html#pre-school">Pre-School Programs</a></li>
-                                <li><a href="./programs.html#elementary">Elementary Program</a></li>
-                                <li><a href="./programs.html#admission">Admissions Process</a></li>
-                            </ul>
-                        </li>
-                        <li class="menu-items hover-underline-animation"><a href="./parents.html">Parents</a>
-                            <ul class="sub-nav-items">
-                                <li><a href="./parents.html#what-is-montessori">What is Montessori?</a></li>
-                                <li><a href="./parents.html#calender">School Calendar</a></li>
-                                <li><a href="./parents.html#reading">Recommended Reading</a></li>
-                            </ul>
-                            </li>
-                        <li class="menu-items hover-underline-animation"><a href="./contact.html">Contact</a></li>
-                    </div>
-                    <li class="icon"> 
-                        <a href="javascript:void(0);" class="icon" onclick="navBarMobile()">
-                            <i class="fa fa-bars"></i>
-                        </a>
-                    </li>
-                </ul>
-            </nav>
-            </header>
-            <section class="head-banner">
+        <header id="nav"></header>
+        <section class="head-banner">
                 <div class="head-overlay">
                     <div class="head-content">
                         <h2 class="main-header">Montessori Lab School</h2>

--- a/main.js
+++ b/main.js
@@ -16,6 +16,38 @@ function openFloat() {
     else{float.classList.remove('open')}
 }
 
+// load shared navigation
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('./nav.html')
+    .then(res => res.text())
+    .then(html => {
+      const holder = document.getElementById('nav');
+      if (holder) {
+        holder.innerHTML = html;
+        setActiveNav();
+      }
+    });
+});
+
+function setActiveNav() {
+  const path = window.location.pathname.split('/').pop();
+  const page = path === '' ? 'index.html' : path;
+  const map = { 'success.html': 'contact.html' };
+  const target = map[page] || page;
+
+  if (target === 'index.html') {
+    const logoLink = document.querySelector('.nav-logo a');
+    if (logoLink) logoLink.classList.add('active');
+  } else {
+    document.querySelectorAll('.menu-items a').forEach(link => {
+      const href = link.getAttribute('href').replace('./', '');
+      if (href === target) {
+        link.parentElement.classList.add('active');
+      }
+    });
+  }
+}
+
 let cardData = [
   {dataOpen:1,
   imgSrc: [

--- a/nav.html
+++ b/nav.html
@@ -1,0 +1,36 @@
+<nav>
+    <ul class="nav-bar" id="topNav">
+        <img class='logo' src="./assets/fav-icon/apple-touch-icon.png" alt="">
+        <li class="nav-logo ">
+            <a class='hover-underline-animation' href="./index.html">
+                <span class="long"> Montessori Lab School </span>
+                <span class="short"> MLS </span>
+            </a>
+            <span class="sub-text">since 1977</span>
+        </li>
+        <li class="phone-nav"><a href="tel:7575488762">(757) 548-8762</a> </li>
+        <div class="menu">
+            <li class="home-sub menu-items hover-underline-animation"><a href="./index.html">Home</a></li>
+            <li class="menu-items hover-underline-animation"><a href="./programs.html">Curriculum</a>
+                <ul class="sub-nav-items">
+                    <li><a href="./programs.html#pre-school">Pre-School Programs</a></li>
+                    <li><a href="./programs.html#elementary">Elementary Program</a></li>
+                    <li><a href="./programs.html#admission">Admissions Process</a></li>
+                </ul>
+            </li>
+            <li class="menu-items hover-underline-animation"><a href="./parents.html">Parents</a>
+                <ul class="sub-nav-items">
+                    <li><a href="./parents.html#what-is-montessori">What is Montessori?</a></li>
+                    <li><a href="./parents.html#calender">School Calendar</a></li>
+                    <li><a href="./parents.html#reading">Recommended Reading</a></li>
+                </ul>
+            </li>
+            <li class="menu-items hover-underline-animation"><a href="./contact.html">Contact</a></li>
+        </div>
+        <li class="icon">
+            <a href="javascript:void(0);" class="icon" onclick="navBarMobile()">
+                <i class="fa fa-bars"></i>
+            </a>
+        </li>
+    </ul>
+</nav>

--- a/parents.html
+++ b/parents.html
@@ -34,44 +34,7 @@
                 <a class='admin-icon' target="_blank" href="./contact.html"><i class="fa-solid fa-file-lines"></i></a>
             </div>
         </div>
-        <header>
-            <nav>
-                <ul class="nav-bar" id="topNav">
-                    <img class='logo' src="./assets/fav-icon/apple-touch-icon.png" alt=""> 
-                    <li class="nav-logo ">
-                        <a class='hover-underline-animation' href="./index.html">
-                            <span class="long"> Montessori Lab School </span>
-                            <span class="short"> MLS </span>
-                        </a> 
-                        <span class="sub-text">since 1977</span>
-                    </li>
-                    <li class="phone-nav"><a href="tel:7575488762">(757) 548-8762</a> </li>
-                    <div class="menu">
-                        <li class="home-sub menu-items hover-underline-animation"><a href="./index.html">Home</a></li>
-                        <li class="menu-items hover-underline-animation"><a href="./programs.html">Curriculum</a>
-                            <ul class="sub-nav-items">
-                                <li><a href="./programs.html#pre-school">Pre-School Programs</a></li>
-                                <li><a href="./programs.html#elementary">Elementary Program</a></li>
-                                <li><a href="./programs.html#admission">Admissions Process</a></li>
-                            </ul>
-                        </li>
-                        <li class=" active menu-items hover-underline-animation"><a href="./parents.html">Parents</a>
-                            <ul class="sub-nav-items">
-                                <li><a href="./parents.html#what-is-montessori">What is Montessori?</a></li>
-                                <li><a href="./parents.html#calender">School Calendar</a></li>
-                                <li><a href="./parents.html#reading">Recommended Reading</a></li>
-                            </ul>
-                            </li>
-                        <li class="menu-items hover-underline-animation"><a href="./contact.html">Contact</a></li>
-                    </div>
-                    <li class="icon"> 
-                        <a href="javascript:void(0);" class="icon" onclick="navBarMobile()">
-                            <i class="fa fa-bars"></i>
-                        </a>
-                    </li>
-                </ul>
-            </nav>
-        </header>    
+        <header id="nav"></header>
         <section class="hero-section">
             <div class="hero-photo hero-2">
                 <div class="photo-overlay">

--- a/programs.html
+++ b/programs.html
@@ -34,44 +34,7 @@
                 <a class='admin-icon' target="_blank" href="./contact.html"><i class="fa-solid fa-file-lines"></i></a>
             </div>
         </div>
-        <header>
-            <nav>
-                <ul class="nav-bar" id="topNav">
-                    <img class='logo' src="./assets/fav-icon/apple-touch-icon.png" alt=""> 
-                    <li class="nav-logo ">
-                        <a class='hover-underline-animation' href="./index.html">
-                            <span class="long"> Montessori Lab School </span>
-                            <span class="short"> MLS </span>
-                        </a> 
-                        <span class="sub-text">since 1977</span>
-                    </li>
-                    <li class="phone-nav"><a href="tel:7575488762">(757) 548-8762</a> </li>
-                    <div class="menu">
-                        <li class="home-sub menu-items hover-underline-animation"><a href="./index.html">Home</a></li>
-                        <li class="active menu-items hover-underline-animation"><a href="./programs.html">Curriculum</a>
-                            <ul class="sub-nav-items">
-                                <li><a href="./programs.html#pre-school">Pre-School Programs</a></li>
-                                <li><a href="./programs.html#elementary">Elementary Program</a></li>
-                                <li><a href="./programs.html#admission">Admissions Process</a></li>
-                            </ul>
-                        </li>
-                        <li class="menu-items hover-underline-animation"><a href="./parents.html">Parents</a>
-                            <ul class="sub-nav-items">
-                                <li><a href="./parents.html#what-is-montessori">What is Montessori?</a></li>
-                                <li><a href="./parents.html#calender">School Calendar</a></li>
-                                <li><a href="./parents.html#reading">Recommended Reading</a></li>
-                            </ul>
-                            </li>
-                        <li class="menu-items hover-underline-animation"><a href="./contact.html">Contact</a></li>
-                    </div>
-                    <li class="icon"> 
-                        <a href="javascript:void(0);" class="icon" onclick="navBarMobile()">
-                            <i class="fa fa-bars"></i>
-                        </a>
-                    </li>
-                </ul>
-            </nav>
-        </header> 
+        <header id="nav"></header>
         <section class="hero-section">
             <div class="hero-photo hero-3">
                 <div class="photo-overlay">

--- a/success.html
+++ b/success.html
@@ -27,44 +27,7 @@
     gtag('config', 'G-GM7D4Q3929');
     </script>
     <body>
-        <header>
-            <nav>
-                <ul class="nav-bar" id="topNav">
-                    <img class='logo' src="./assets/fav-icon/apple-touch-icon.png" alt=""> 
-                    <li class="nav-logo ">
-                        <a class='hover-underline-animation' href="./index.html">
-                            <span class="long"> Montessori Lab School </span>
-                            <span class="short"> MLS </span>
-                        </a> 
-                        <span class="sub-text">since 1977</span>
-                    </li>
-                    <li class="phone-nav"><a href="tel:7575488762">(757) 548-8762</a> </li>
-                    <div class="menu">
-                        <li class="home-sub menu-items hover-underline-animation"><a href="./index.html">Home</a></li>
-                        <li class="menu-items hover-underline-animation"><a href="./programs.html">Curriculum</a>
-                            <ul class="sub-nav-items">
-                                <li><a href="./programs.html#pre-school">Pre-School Programs</a></li>
-                                <li><a href="./programs.html#elementary">Elementary Program</a></li>
-                                <li><a href="./programs.html#admission">Admissions Process</a></li>
-                            </ul>
-                        </li>
-                        <li class="menu-items hover-underline-animation"><a href="./parents.html">Parents</a>
-                            <ul class="sub-nav-items">
-                                <li><a href="./parents.html#what-is-montessori">What is Montessori?</a></li>
-                                <li><a href="./parents.html#calender">School Calendar</a></li>
-                                <li><a href="./parents.html#reading">Recommended Reading</a></li>
-                            </ul>
-                            </li>
-                        <li class="active menu-items hover-underline-animation"><a href="./contact.html">Contact</a></li>
-                    </div>
-                    <li class="icon"> 
-                        <a href="javascript:void(0);" class="icon" onclick="navBarMobile()">
-                            <i class="fa fa-bars"></i>
-                        </a>
-                    </li>
-                </ul>
-            </nav>
-        </header>    
+        <header id="nav"></header>
         
         <section class="white-space"></section>
         <section class="success-section">


### PR DESCRIPTION
## Summary
- centralize navigation in `nav.html` partial retaining `topNav` ID for mobile toggling
- inject shared nav into each page and automatically highlight current link via `setActiveNav`
- replace per-page `<nav>` blocks with `<header id="nav"></header>` placeholders
- document new navigation setup in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b49e2adfb08322b5d57e548428522d